### PR TITLE
Implement Formspree-based contact submission

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-hook-form": "^7.57.0",
     "react-intersection-observer": "^9.8.1",
     "react-router-dom": "^6.22.3",
+    "@formspree/react": "^3.4.0",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.3.4",

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -11,19 +11,16 @@ export interface ContactFormData {
 }
 
 export async function submitContactForm(data: ContactFormData): Promise<void> {
-  // Simulate API call delay
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  
-  // Log the form data for development purposes
-  console.log('Contact form submitted:', data);
-  
-  // In a real implementation, this would:
-  // 1. Validate the data server-side
-  // 2. Send email notification
-  // 3. Store in database
-  // 4. Return success/error response
-  
-  // For now, we'll just simulate success
-  // Uncomment the line below to simulate an error for testing
-  // throw new Error('Simulated submission error');
-} 
+  const endpoint = 'https://formspree.io/f/xdkzkdnk';
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Failed to submit form');
+  }
+}

--- a/src/components/sections/ContactForm.tsx
+++ b/src/components/sections/ContactForm.tsx
@@ -72,7 +72,11 @@ function ContactForm() {
       form.reset();
     } catch (err) {
       console.error("Form submission error:", err);
-      setError("Something went wrong. Please try again later.");
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Something went wrong. Please try again later.");
+      }
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- remove local server and example API env variable
- add `@formspree/react` dependency
- post contact form data directly to Formspree

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840cb4b69548330a63806cbd36966f2